### PR TITLE
Added Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+
+rvm:
+  - 2.2.2
+script:
+  - bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '2.2.1'
+ruby '2.2.2'
 
 gem 'rspec', '~> 3.4.0'
 gem 'sinatra', '~> 1.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ DEPENDENCIES
   sinatra (~> 1.4.5)
 
 RUBY VERSION
-   ruby 2.2.1p85
+   ruby 2.2.2
 
 BUNDLED WITH
    1.12.4

--- a/spec/lib/fizzbuzz_spec.rb
+++ b/spec/lib/fizzbuzz_spec.rb
@@ -3,38 +3,38 @@ require 'fizzbuzz'
 describe 'fizzbuzz' do
 
 	it 'returns fizz when 3' do
-		expect(fizzbuzz(3)).to eq 'fizz'
+		expect(FizzBuzzApp.fizzbuzz(3)).to eq 'fizz'
 	end
 
 	it  'returns buzz when 5' do
-		expect(fizzbuzz(5)).to eq 'buzz'
+		expect(FizzBuzzApp.fizzbuzz(5)).to eq 'buzz'
 	end
 
 	it  'returns 2 when 2' do
-		expect(fizzbuzz(2)).to eq '2'
+		expect(FizzBuzzApp.fizzbuzz(2)).to eq '2'
 	end
 
 	it "3 and 5 should equal fizz and buzz" do
 		a = [*1..100]
 		a.each do |n|
 			if n % 3 == 0 && n % 15 != 0
-				expect(fizzbuzz(n)).to eq 'fizz'
+				expect(FizzBuzzApp.fizzbuzz(n)).to eq 'fizz'
 			elsif n % 5 == 0 && n % 15 != 0
-				expect(fizzbuzz(n)).to eq 'buzz'
+				expect(FizzBuzzApp.fizzbuzz(n)).to eq 'buzz'
 			else
-				expect(fizzbuzz(n)).to eq n.to_s unless n % 15 == 0
+				expect(FizzBuzzApp.fizzbuzz(n)).to eq n.to_s unless n % 15 == 0
 			end
 		end
 	end
 
 	it 'returns fizzbuzz when 15 is passed' do
-		expect(fizzbuzz(15)).to eq 'fizzbuzz'
+		expect(FizzBuzzApp.fizzbuzz(15)).to eq 'fizzbuzz'
 	end
 
 	it "tests for fizzbuzz" do
 		mod5 = [*1..100].select {|i | i % 15 == 0 }
 		mod5.each do |n|
-			expect(fizzbuzz(n)).to eq 'fizzbuzz'
+			expect(FizzBuzzApp.fizzbuzz(n)).to eq 'fizzbuzz'
 		end
 	end
 
@@ -42,12 +42,12 @@ describe 'fizzbuzz' do
     @n = '!@#$%^&*()[]{}"\'|<>,./?~™£¢∞§¡¶•ªº≠=⁄€‹›ﬁﬂ‡°·‚±ÚÆ”’¯˘¿;: '.split('')
     @n << [*"a".."z"] << [*"A".."Z"]
     @n.flatten.each do |x|
-      expect(fizzbuzz(x)).to eq "Fail! Not an integer"
+      expect(FizzBuzzApp.fizzbuzz(x)).to eq "Fail! Not an integer"
     end
     random_words = ['14t','?123','2 34','_+34jif','jhfhfl','','  ','12three','EV%4',]
     random_words.each do |x|
       if x.chars.any? {|c| @n.include? c}
-        expect(fizzbuzz(x)).to eq "Fail! Not an integer"
+        expect(FizzBuzzApp.fizzbuzz(x)).to eq "Fail! Not an integer"
       end
     end
   end
@@ -57,7 +57,7 @@ describe 'fizzbuzz' do
     a = [* 101..10000]
     b << a
     b.flatten.each do |i|
-      expect(fizzbuzz(i)).to eq "Integer outside of range. Try again!"
+      expect(FizzBuzzApp.fizzbuzz(i)).to eq "Integer outside of range. Try again!"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,23 +49,19 @@ RSpec.configure do |config|
   # get run.
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
-
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
-
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
   config.warnings = true
-
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
@@ -75,18 +71,15 @@ RSpec.configure do |config|
     # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
   end
-
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
-
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value


### PR DESCRIPTION
If we are likely to have multiple people contributing to this, it would likely be useful to be able to assess that their additions will not break any part of the existing tests. As such I have added in the .travis.yml file to allow Travis CI to work on the repository. Also updated gemfiles to use 2.2.2 (for the security fix & Travis was requesting use of 2.2.2), and the specs have been updated to allow them to access the method.

To make this work on your repository, you will need to set up a travis-ci profile and enable the webhook in github (explained on the travis site).
